### PR TITLE
KeepAlive interceptor based support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+#### Forked project with a goal to add missing and important rsocket protocol features. Effort will be made to implement them as plugins to share with [rsocket-java-backport](https://github.com/mostroverkhov/rsocket-java-backport) and simplify upstream merges
+
 # RSocket
 
 [![Join the chat at https://gitter.im/RSocket/reactivesocket-java](https://badges.gitter.im/RSocket/reactivesocket-java.svg)](https://gitter.im/RSocket/reactivesocket-java?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/rsocket-core/src/main/java/io/rsocket/RSocketResponder.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketResponder.java
@@ -20,8 +20,6 @@ import static io.rsocket.Frame.Request.initialRequestN;
 import static io.rsocket.frame.FrameHeaderFlyweight.FLAGS_C;
 import static io.rsocket.frame.FrameHeaderFlyweight.FLAGS_M;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.util.collection.IntObjectHashMap;
 import io.rsocket.exceptions.ApplicationException;
 import io.rsocket.internal.LimitableRequestPublisher;
@@ -225,8 +223,6 @@ class RSocketServer implements RSocket {
           return handleRequestResponse(streamId, requestResponse(new PayloadImpl(frame)));
         case CANCEL:
           return handleCancelFrame(streamId);
-        case KEEPALIVE:
-          return handleKeepAliveFrame(frame);
         case REQUEST_N:
           return handleRequestN(streamId, frame);
         case REQUEST_STREAM:
@@ -360,16 +356,6 @@ class RSocketServer implements RSocket {
     frames.onNext(new PayloadImpl(firstFrame));
 
     return handleStream(streamId, requestChannel(payloads), initialRequestN(firstFrame));
-  }
-
-  private Mono<Void> handleKeepAliveFrame(Frame frame) {
-    return Mono.fromRunnable(
-        () -> {
-          if (Frame.Keepalive.hasRespondFlag(frame)) {
-            ByteBuf data = Unpooled.wrappedBuffer(frame.getData());
-            sendProcessor.onNext(Frame.Keepalive.from(data, false));
-          }
-        });
   }
 
   private Mono<Void> handleCancelFrame(int streamId) {

--- a/rsocket-core/src/main/java/io/rsocket/internal/ConnectionMux.java
+++ b/rsocket-core/src/main/java/io/rsocket/internal/ConnectionMux.java
@@ -2,12 +2,11 @@ package io.rsocket.internal;
 
 import static java.util.stream.Collectors.toList;
 
+import io.rsocket.DuplexConnection;
+import io.rsocket.Frame;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
-
-import io.rsocket.DuplexConnection;
-import io.rsocket.Frame;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;

--- a/rsocket-core/src/main/java/io/rsocket/keepalive/CloseOnKeepAliveTimeout.java
+++ b/rsocket-core/src/main/java/io/rsocket/keepalive/CloseOnKeepAliveTimeout.java
@@ -1,0 +1,33 @@
+package io.rsocket.keepalive;
+
+import io.rsocket.exceptions.ConnectionException;
+import java.util.function.Consumer;
+import reactor.core.publisher.Mono;
+
+public class CloseOnKeepAliveTimeout implements Consumer<KeepAlives> {
+  private final Consumer<Throwable> errConsumer;
+
+  public CloseOnKeepAliveTimeout(Consumer<Throwable> errConsumer) {
+    this.errConsumer = errConsumer;
+  }
+
+  @Override
+  public void accept(KeepAlives keepAlives) {
+    keepAlives
+        .keepAlive()
+        .ofType(KeepAlive.KeepAliveMissing.class)
+        .next()
+        .flatMap(keepAliveMissing -> keepAlives.closeConnection().then(Mono.just(keepAliveMissing)))
+        .subscribe(
+            keepAliveMissing -> errConsumer.accept(keepAliveMissingError(keepAliveMissing)),
+            errConsumer::accept);
+  }
+
+  private Exception keepAliveMissingError(KeepAlive.KeepAliveMissing keepAliveMissing) {
+    String message =
+        String.format(
+            "Missed %d keep-alive acks with ack timeout of %d ms",
+            keepAliveMissing.getCurrentTicks(), keepAliveMissing.getTickPeriod().toMillis());
+    return new ConnectionException(message);
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/keepalive/KeepAlive.java
+++ b/rsocket-core/src/main/java/io/rsocket/keepalive/KeepAlive.java
@@ -1,0 +1,43 @@
+package io.rsocket.keepalive;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+
+public interface KeepAlive {
+
+  class KeepAliveAvailable implements KeepAlive {
+    private final ByteBuffer data;
+
+    public KeepAliveAvailable(ByteBuffer data) {
+      this.data = data;
+    }
+
+    public ByteBuffer getData() {
+      return data;
+    }
+  }
+
+  class KeepAliveMissing implements KeepAlive {
+    private final Duration tickPeriod;
+    private final int timeoutTicks;
+    private final int currentTicks;
+
+    public KeepAliveMissing(Duration tickPeriod, int timeoutTicks, int currentTicks) {
+      this.tickPeriod = tickPeriod;
+      this.timeoutTicks = timeoutTicks;
+      this.currentTicks = currentTicks;
+    }
+
+    public Duration getTickPeriod() {
+      return tickPeriod;
+    }
+
+    public int getTimeoutTicks() {
+      return timeoutTicks;
+    }
+
+    public int getCurrentTicks() {
+      return currentTicks;
+    }
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/keepalive/KeepAliveRequesterConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/keepalive/KeepAliveRequesterConnection.java
@@ -1,0 +1,102 @@
+package io.rsocket.keepalive;
+
+import io.netty.buffer.Unpooled;
+import io.rsocket.DuplexConnection;
+import io.rsocket.DuplexConnectionProxy;
+import io.rsocket.Frame;
+import io.rsocket.FrameType;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxProcessor;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.UnicastProcessor;
+
+public class KeepAliveRequesterConnection extends DuplexConnectionProxy {
+
+  private final FluxProcessor<KeepAlive, KeepAlive> keepAlives =
+      UnicastProcessor.<KeepAlive>create().serialize();
+  private final Duration tickPeriod;
+  private final int timeoutTicks;
+  private final Supplier<ByteBuffer> frameDataFactory;
+  private Consumer<Throwable> errConsumer;
+  private final long timeoutMillis;
+  private volatile long timeLastTickSentMs;
+  private final AtomicInteger missedAckCounter = new AtomicInteger();
+  private volatile Disposable keepAliveSubs;
+
+  public KeepAliveRequesterConnection(
+      DuplexConnection zero,
+      Duration tickPeriod,
+      int timeoutTicks,
+      Supplier<ByteBuffer> frameDataFactory,
+      Consumer<Throwable> errConsumer) {
+    super(zero);
+    this.tickPeriod = tickPeriod;
+    this.timeoutTicks = timeoutTicks;
+    this.frameDataFactory = frameDataFactory;
+    this.errConsumer = errConsumer;
+    this.timeoutMillis = tickPeriod.toMillis() * timeoutTicks;
+  }
+
+  @Override
+  public Flux<Frame> receive() {
+    return super.receive()
+        .doOnSubscribe(s -> startPeriodicKeepAlive())
+        .doOnNext(this::handleKeepAliveResponse)
+        .doOnError(err -> disposeKeepAlive());
+  }
+
+  private void handleKeepAliveResponse(Frame f) {
+    if (isKeepAliveResponse(f)) {
+      missedAckCounter.set(0);
+      keepAlives.onNext(new KeepAlive.KeepAliveAvailable(f.getData()));
+      timeLastTickSentMs = System.currentTimeMillis();
+    }
+  }
+
+  public Flux<KeepAlive> keepAlive() {
+    return keepAlives;
+  }
+
+  private boolean isKeepAliveResponse(Frame f) {
+    return f.getType() == FrameType.KEEPALIVE && !Frame.Keepalive.hasRespondFlag(f);
+  }
+
+  private void startPeriodicKeepAlive() {
+    timeLastTickSentMs = System.currentTimeMillis();
+    keepAliveSubs =
+        Flux.interval(tickPeriod)
+            .concatMap(i -> sendKeepAlive())
+            .subscribe(
+                __ -> {},
+                err -> {
+                  errConsumer.accept(err);
+                  keepAlives.onComplete();
+                  close().subscribe();
+                });
+  }
+
+  private void disposeKeepAlive() {
+    if (keepAliveSubs != null) {
+      keepAliveSubs.dispose();
+    }
+    keepAlives.onComplete();
+  }
+
+  private Mono<Void> sendKeepAlive() {
+    long now = System.currentTimeMillis();
+    if (now - timeLastTickSentMs > timeoutMillis) {
+      int count = missedAckCounter.incrementAndGet();
+      if (count >= timeoutTicks) {
+        // TODO fix race with KeepAlive.KeepAliveAvailable
+        keepAlives.onNext(new KeepAlive.KeepAliveMissing(tickPeriod, timeoutTicks, count));
+      }
+    }
+    return sendOne(Frame.Keepalive.from(Unpooled.wrappedBuffer(frameDataFactory.get()), true));
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/keepalive/KeepAliveResponderConnection.java
+++ b/rsocket-core/src/main/java/io/rsocket/keepalive/KeepAliveResponderConnection.java
@@ -1,0 +1,37 @@
+package io.rsocket.keepalive;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.rsocket.DuplexConnection;
+import io.rsocket.DuplexConnectionProxy;
+import io.rsocket.Frame;
+import io.rsocket.FrameType;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxProcessor;
+import reactor.core.publisher.UnicastProcessor;
+
+public class KeepAliveResponderConnection extends DuplexConnectionProxy {
+
+  private final FluxProcessor<Frame, Frame> sender = UnicastProcessor.<Frame>create().serialize();
+
+  public KeepAliveResponderConnection(DuplexConnection zeroConn) {
+    super(zeroConn);
+    zeroConn.send(sender).subscribe(Void -> {}, err -> {});
+  }
+
+  @Override
+  public Flux<Frame> receive() {
+    return super.receive()
+        .doOnNext(
+            f -> {
+              if (isKeepAliveRequest(f)) {
+                ByteBuf data = Unpooled.wrappedBuffer(f.getData());
+                sender.onNext(Frame.Keepalive.from(data, false));
+              }
+            });
+  }
+
+  private boolean isKeepAliveRequest(Frame f) {
+    return f.getType().equals(FrameType.KEEPALIVE) && Frame.Keepalive.hasRespondFlag(f);
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/keepalive/KeepAlives.java
+++ b/rsocket-core/src/main/java/io/rsocket/keepalive/KeepAlives.java
@@ -1,0 +1,22 @@
+package io.rsocket.keepalive;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public class KeepAlives {
+  private Flux<KeepAlive> keepAlive;
+  private Mono<Void> closeConnection;
+
+  public KeepAlives(Flux<KeepAlive> keepAlive, Mono<Void> closeConnection) {
+    this.keepAlive = keepAlive;
+    this.closeConnection = closeConnection;
+  }
+
+  public Flux<KeepAlive> keepAlive() {
+    return keepAlive;
+  }
+
+  public Mono<Void> closeConnection() {
+    return closeConnection;
+  }
+}

--- a/rsocket-core/src/main/java/io/rsocket/lease/LeaseInterceptor.java
+++ b/rsocket-core/src/main/java/io/rsocket/lease/LeaseInterceptor.java
@@ -85,7 +85,8 @@ public class LeaseInterceptor implements DuplexConnectionInterceptor {
             (conn, args) ->
                 new RequestInboundConnection(tag, conn, ctx, args.getResponderLeaseManager())),
         emptyList(),
-        singletonList((conn, args) -> new LeaseInConnection(tag, conn, ctx, args.getLeaseConsumer())));
+        singletonList(
+            (conn, args) -> new LeaseInConnection(tag, conn, ctx, args.getLeaseConsumer())));
   }
 
   public static LeaseInterceptor ofClient(

--- a/rsocket-core/src/main/java/io/rsocket/lease/PerConnectionInterceptor.java
+++ b/rsocket-core/src/main/java/io/rsocket/lease/PerConnectionInterceptor.java
@@ -2,9 +2,9 @@ package io.rsocket.lease;
 
 import static java.util.stream.Collectors.toList;
 
-import io.rsocket.internal.ConnectionMux;
 import io.rsocket.DuplexConnection;
 import io.rsocket.internal.ConnectionDemux;
+import io.rsocket.internal.ConnectionMux;
 import io.rsocket.plugins.DuplexConnectionInterceptor;
 import io.rsocket.plugins.PluginRegistry;
 import java.util.Arrays;
@@ -25,10 +25,8 @@ public class PerConnectionInterceptor implements DuplexConnectionInterceptor {
       List<DuplexConnectionInterceptor> interceptors = create();
       duplexConnection = intercept(duplexConnection, Type.SOURCE, interceptors);
 
-      ConnectionDemux demux =
-          new ConnectionDemux(duplexConnection, empty);
-      DuplexConnection init =
-              intercept(demux.asInitConnection(), Type.INIT, interceptors);
+      ConnectionDemux demux = new ConnectionDemux(duplexConnection, empty);
+      DuplexConnection init = intercept(demux.asInitConnection(), Type.INIT, interceptors);
       DuplexConnection zero =
           intercept(demux.asStreamZeroConnection(), Type.STREAM_ZERO, interceptors);
       DuplexConnection client = intercept(demux.asClientConnection(), Type.CLIENT, interceptors);

--- a/rsocket-core/src/main/java/io/rsocket/plugins/PerTypeDuplexConnectionInterceptor.java
+++ b/rsocket-core/src/main/java/io/rsocket/plugins/PerTypeDuplexConnectionInterceptor.java
@@ -1,0 +1,23 @@
+package io.rsocket.plugins;
+
+import io.rsocket.DuplexConnection;
+import java.util.function.Function;
+
+public class PerTypeDuplexConnectionInterceptor implements DuplexConnectionInterceptor {
+  private final Type type;
+  private final Function<DuplexConnection, DuplexConnection> interceptor;
+
+  public PerTypeDuplexConnectionInterceptor(
+      Type type, Function<DuplexConnection, DuplexConnection> interceptor) {
+    this.type = type;
+    this.interceptor = interceptor;
+  }
+
+  @Override
+  public DuplexConnection apply(Type type, DuplexConnection duplexConnection) {
+    if (this.type.equals(type)) {
+      duplexConnection = interceptor.apply(duplexConnection);
+    }
+    return duplexConnection;
+  }
+}

--- a/rsocket-core/src/test/java/io/rsocket/MetadataPushTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/MetadataPushTest.java
@@ -24,8 +24,7 @@ public class MetadataPushTest {
   }
 
   private void testResponderMetadataPush(
-      String connName, Function<ConnectionDemux, DuplexConnection> connF)
-      throws Exception {
+      String connName, Function<ConnectionDemux, DuplexConnection> connF) throws Exception {
     DirectProcessor<Frame> sender = DirectProcessor.create();
     DirectProcessor<Frame> receiver = DirectProcessor.create();
     DuplexConnection conn =

--- a/rsocket-core/src/test/java/io/rsocket/RSocketClientTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/RSocketClientTest.java
@@ -52,11 +52,6 @@ public class RSocketClientTest {
   @Rule public final ClientSocketRule rule = new ClientSocketRule();
 
   @Test(timeout = 2_000)
-  public void testKeepAlive() throws Exception {
-    assertThat("Unexpected frame sent.", rule.connection.awaitSend().getType(), is(KEEPALIVE));
-  }
-
-  @Test(timeout = 2_000)
   public void testInvalidFrameOnStream0() {
     rule.connection.addToReceivedBuffer(Frame.RequestN.from(0, 10));
     assertThat("Unexpected errors.", rule.errors, hasSize(1));
@@ -195,12 +190,7 @@ public class RSocketClientTest {
     @Override
     protected RSocketClient newRSocket() {
       return new RSocketClient(
-          connection,
-          throwable -> errors.add(throwable),
-          StreamIdSupplier.clientSupplier(),
-          Duration.ofMillis(100),
-          Duration.ofMillis(100),
-          4);
+          connection, throwable -> errors.add(throwable), StreamIdSupplier.clientSupplier());
     }
 
     public int getStreamIdForRequestType(FrameType expectedFrameType) {

--- a/rsocket-core/src/test/java/io/rsocket/internal/ClientServerInputMultiplexerTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/internal/ClientServerInputMultiplexerTest.java
@@ -22,11 +22,9 @@ import io.rsocket.Frame;
 import io.rsocket.frame.SetupFrameFlyweight;
 import io.rsocket.plugins.PluginRegistry;
 import io.rsocket.test.util.TestDuplexConnection;
-
+import io.rsocket.util.PayloadImpl;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import io.rsocket.util.PayloadImpl;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -63,10 +61,10 @@ public class ClientServerInputMultiplexerTest {
         .doOnNext(f -> connectionFrames.incrementAndGet())
         .subscribe();
     multiplexer
-            .asInitConnection()
-            .receive()
-            .doOnNext(f -> initFrames.incrementAndGet())
-            .subscribe();
+        .asInitConnection()
+        .receive()
+        .doOnNext(f -> initFrames.incrementAndGet())
+        .subscribe();
 
     source.addToReceivedBuffer(Frame.Error.from(1, new Exception()));
     assertEquals(1, clientFrames.get());
@@ -102,13 +100,13 @@ public class ClientServerInputMultiplexerTest {
   private Frame setupFrame() {
     int duration = (int) Duration.ZERO.toMillis();
     Frame setupFrame =
-            Frame.Setup.from(
-                    SetupFrameFlyweight.FLAGS_STRICT_INTERPRETATION,
-                    duration,
-                     duration,
-                    "application/binary",
-                    "application/binary",
-                    PayloadImpl.EMPTY);
+        Frame.Setup.from(
+            SetupFrameFlyweight.FLAGS_STRICT_INTERPRETATION,
+            duration,
+            duration,
+            "application/binary",
+            "application/binary",
+            PayloadImpl.EMPTY);
     return setupFrame;
   }
 }

--- a/rsocket-core/src/test/java/io/rsocket/keepalive/KeepAliveRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/keepalive/KeepAliveRequesterTest.java
@@ -1,0 +1,110 @@
+package io.rsocket.keepalive;
+
+import static java.time.Duration.*;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.rsocket.DuplexConnection;
+import io.rsocket.Frame;
+import io.rsocket.FrameType;
+import io.rsocket.test.util.LocalDuplexConnection;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.Test;
+import reactor.core.publisher.DirectProcessor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+
+public class KeepAliveRequesterTest {
+
+  @Test
+  public void periodicRequestsSent() throws Exception {
+    DirectProcessor<Frame> sender = DirectProcessor.create();
+    DirectProcessor<Frame> receiver = DirectProcessor.create();
+    LocalDuplexConnection conn = new LocalDuplexConnection("conn", sender, receiver);
+    KeepAliveRequesterConnection receiveConn = newConn(conn);
+    Mono.delay(ofMillis(100), Schedulers.elastic())
+        .flatMapMany(__ -> receiveConn.receive())
+        .subscribe();
+
+    StepVerifier.create(sender.take(4))
+        .expectNextMatches(this::isKeepAliveRequest)
+        .expectNextMatches(this::isKeepAliveRequest)
+        .expectNextMatches(this::isKeepAliveRequest)
+        .expectNextMatches(this::isKeepAliveRequest)
+        .expectComplete()
+        .verify(ofSeconds(3));
+  }
+
+  @Test
+  public void inboundKeepAlivesAreReported() throws Exception {
+    DirectProcessor<Frame> sender = DirectProcessor.create();
+    DirectProcessor<Frame> receiver = DirectProcessor.create();
+    LocalDuplexConnection conn = new LocalDuplexConnection("conn", sender, receiver);
+    KeepAliveRequesterConnection receiveConn = newConn(conn);
+    receiveConn.receive().subscribe();
+
+    Flux.interval(ofMillis(100), ofMillis(500), Schedulers.elastic())
+        .take(2)
+        .subscribe(__ -> receiver.onNext(responseFrame("hello")));
+
+    StepVerifier.create(receiveConn.keepAlive().takeUntilOther(Mono.delay(Duration.ofSeconds(2))))
+        .expectNextMatches(keepAlive -> isKeepAliveAvailable(keepAlive, "hello"))
+        .expectNextMatches(keepAlive -> isKeepAliveAvailable(keepAlive, "hello"))
+        .expectComplete()
+        .verify(ofSeconds(3));
+  }
+
+  @Test
+  public void missingInboundKeepAlivesAreReported() throws Exception {
+    DirectProcessor<Frame> sender = DirectProcessor.create();
+    DirectProcessor<Frame> receiver = DirectProcessor.create();
+    LocalDuplexConnection conn = new LocalDuplexConnection("conn", sender, receiver);
+    KeepAliveRequesterConnection receiveConn = newConn(conn);
+    receiveConn.receive().subscribe();
+
+    StepVerifier.create(
+            receiveConn.keepAlive().takeUntilOther(Mono.delay(Duration.ofSeconds(4))).take(2))
+        .expectNextMatches(keepAlive -> isKeepAliveMissing(keepAlive, 3))
+        .expectNextMatches(keepAlive -> isKeepAliveMissing(keepAlive, 4))
+        .expectComplete()
+        .verify(ofSeconds(5));
+  }
+
+  private Frame responseFrame(String data) {
+    Charset utf8 = StandardCharsets.UTF_8;
+    ByteBuf hello = Unpooled.wrappedBuffer(utf8.encode(data));
+    return Frame.Keepalive.from(hello, false);
+  }
+
+  private boolean isKeepAliveRequest(Frame f) {
+    return f.getType().equals(FrameType.KEEPALIVE) && Frame.Keepalive.hasRespondFlag(f);
+  }
+
+  private boolean isKeepAliveAvailable(KeepAlive keepAlive, String expectedData) {
+    return keepAlive instanceof KeepAlive.KeepAliveAvailable
+        && expectedData.equals(getData(keepAlive));
+  }
+
+  private boolean isKeepAliveMissing(KeepAlive keepAlive, int missingCount) {
+    return keepAlive instanceof KeepAlive.KeepAliveMissing && missingCount == getCount(keepAlive);
+  }
+
+  private String getData(KeepAlive keepAlive) {
+    return StandardCharsets.UTF_8
+        .decode(((KeepAlive.KeepAliveAvailable) keepAlive).getData())
+        .toString();
+  }
+
+  private int getCount(KeepAlive keepAlive) {
+    return ((KeepAlive.KeepAliveMissing) keepAlive).getCurrentTicks();
+  }
+
+  private KeepAliveRequesterConnection newConn(DuplexConnection conn) {
+    return new KeepAliveRequesterConnection(
+        conn, ofMillis(500), 3, () -> Frame.NULL_BYTEBUFFER, err -> {});
+  }
+}

--- a/rsocket-core/src/test/java/io/rsocket/keepalive/KeepAliveResponderTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/keepalive/KeepAliveResponderTest.java
@@ -1,0 +1,65 @@
+package io.rsocket.keepalive;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.rsocket.Frame;
+import io.rsocket.FrameType;
+import io.rsocket.test.util.LocalDuplexConnection;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.junit.Test;
+import reactor.core.publisher.DirectProcessor;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+
+public class KeepAliveResponderTest {
+
+  @Test
+  public void respondsToKeepAliveRequest() throws Exception {
+    DirectProcessor<Frame> sender = DirectProcessor.create();
+    DirectProcessor<Frame> receiver = DirectProcessor.create();
+    LocalDuplexConnection conn = new LocalDuplexConnection("conn", sender, receiver);
+    Charset utf8 = StandardCharsets.UTF_8;
+    ByteBuf hello = Unpooled.wrappedBuffer(utf8.encode("hello"));
+    KeepAliveResponderConnection keepAliveResponderConnection =
+        new KeepAliveResponderConnection(conn);
+
+    keepAliveResponderConnection.receive().subscribe();
+
+    Mono.delay(Duration.ofMillis(100), Schedulers.elastic())
+        .subscribe(__ -> receiver.onNext(Frame.Keepalive.from(hello, true)));
+
+    StepVerifier.create(sender.next())
+        .expectNextMatches(
+            f ->
+                "hello".equals(f.getDataUtf8())
+                    && f.getType().equals(FrameType.KEEPALIVE)
+                    && !Frame.Keepalive.hasRespondFlag(f))
+        .expectComplete()
+        .verify(Duration.ofSeconds(2));
+  }
+
+  @Test
+  public void ignoreKeepAliveResponse() throws Exception {
+    DirectProcessor<Frame> sender = DirectProcessor.create();
+    DirectProcessor<Frame> receiver = DirectProcessor.create();
+    LocalDuplexConnection conn = new LocalDuplexConnection("conn", sender, receiver);
+    Charset utf8 = StandardCharsets.UTF_8;
+    ByteBuf hello = Unpooled.wrappedBuffer(utf8.encode("hello"));
+    KeepAliveResponderConnection keepAliveResponderConnection =
+        new KeepAliveResponderConnection(conn);
+
+    keepAliveResponderConnection.receive().subscribe();
+
+    Mono.delay(Duration.ofMillis(100), Schedulers.elastic())
+        .subscribe(__ -> receiver.onNext(Frame.Keepalive.from(hello, false)));
+
+    StepVerifier.create(sender.next().takeUntilOther(Mono.delay(Duration.ofSeconds(3))))
+        .expectSubscription()
+        .expectNoEvent(Duration.ofSeconds(2))
+        .expectComplete()
+        .verify();
+  }
+}

--- a/rsocket-examples/src/main/java/io/rsocket/examples/transport/tcp/metadata/MetadataPushTest.java
+++ b/rsocket-examples/src/main/java/io/rsocket/examples/transport/tcp/metadata/MetadataPushTest.java
@@ -1,69 +1,78 @@
 package io.rsocket.examples.transport.tcp.metadata;
 
+import static java.time.Duration.ofSeconds;
+
 import io.rsocket.*;
 import io.rsocket.transport.netty.client.TcpClientTransport;
 import io.rsocket.transport.netty.server.NettyContextCloseable;
 import io.rsocket.transport.netty.server.TcpServerTransport;
 import io.rsocket.util.PayloadImpl;
+import java.util.Date;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.Date;
-
-import static java.time.Duration.ofSeconds;
-
 public class MetadataPushTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger("io.rsocket.examples.metadata_push");
+  private static final Logger LOGGER = LoggerFactory.getLogger("io.rsocket.examples.metadata_push");
 
-    public static void main(String[] args) {
+  public static void main(String[] args) {
 
-        NettyContextCloseable nettyContextCloseable =
-                RSocketFactory.receive()
-                        .acceptor(
-                                (setup, reactiveSocket) ->
-                                        Mono.just(
-                                                new AbstractRSocket() {
-                                                    @Override
-                                                    public Mono<Payload> requestResponse(Payload payload) {
-                                                        return Mono.just(new PayloadImpl("Server Response " + new Date()));
-                                                    }
+    NettyContextCloseable nettyContextCloseable =
+        RSocketFactory.receive()
+            .acceptor(
+                (setup, reactiveSocket) ->
+                    Mono.just(
+                        new AbstractRSocket() {
+                          @Override
+                          public Mono<Payload> requestResponse(Payload payload) {
+                            return Mono.just(new PayloadImpl("Server Response " + new Date()));
+                          }
 
-                                                    @Override
-                                                    public Mono<Void> metadataPush(Payload payload) {
-                                                        LOGGER.info(new Date() + " server: metadata receive - " + payload.getMetadataUtf8());
-                                                        return reactiveSocket
-                                                                .metadataPush(new PayloadImpl("", "server metadata"));
-                                                    }
-                                                }))
-                        .transport(TcpServerTransport.create("localhost", 7000))
-                        .start()
-                        .block();
+                          @Override
+                          public Mono<Void> metadataPush(Payload payload) {
+                            LOGGER.info(
+                                new Date()
+                                    + " server: metadata receive - "
+                                    + payload.getMetadataUtf8());
+                            return reactiveSocket.metadataPush(
+                                new PayloadImpl("", "server metadata"));
+                          }
+                        }))
+            .transport(TcpServerTransport.create("localhost", 7000))
+            .start()
+            .block();
 
-        RSocket clientSocket =
-                RSocketFactory.connect()
-                        .acceptor(
-                                () -> rsocket -> new AbstractRSocket() {
-                                    @Override
-                                    public Mono<Void> metadataPush(Payload payload) {
-                                        LOGGER.info(new Date() + " client : metadata receive - " + payload.getMetadataUtf8());
-                                        return Mono.empty();
-                                    }
-                                })
-                        .transport(TcpClientTransport.create("localhost", 7000))
-                        .start()
-                        .block();
+    RSocket clientSocket =
+        RSocketFactory.connect()
+            .acceptor(
+                () ->
+                    rsocket ->
+                        new AbstractRSocket() {
+                          @Override
+                          public Mono<Void> metadataPush(Payload payload) {
+                            LOGGER.info(
+                                new Date()
+                                    + " client : metadata receive - "
+                                    + payload.getMetadataUtf8());
+                            return Mono.empty();
+                          }
+                        })
+            .transport(TcpClientTransport.create("localhost", 7000))
+            .start()
+            .block();
 
-        Flux.interval(ofSeconds(1))
-                .flatMap(
-                        signal -> clientSocket
-                                .metadataPush(new PayloadImpl("", "client metadata"))
-                                .onErrorResume(
-                                        err -> Mono.<Void>empty().doOnTerminate(() -> LOGGER.info("Error: " + err))))
-                .subscribe();
+    Flux.interval(ofSeconds(1))
+        .flatMap(
+            signal ->
+                clientSocket
+                    .metadataPush(new PayloadImpl("", "client metadata"))
+                    .onErrorResume(
+                        err ->
+                            Mono.<Void>empty().doOnTerminate(() -> LOGGER.info("Error: " + err))))
+        .subscribe();
 
-        clientSocket.onClose().block();
-    }
+    clientSocket.onClose().block();
+  }
 }


### PR DESCRIPTION
This change was mainly necessary because of changes to how ConnectionDemux (ClientServerConnectionMultiplexer) groups incoming frames to fix metadata push #6. 
Also addresses #2  by adding API to handle incoming keepAlives data and react to missing keepAlives on application level