### PR TITLE
RSocketRequester: fix Frame sendProcessor gets poisoned by DuplexConnection.send error

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
@@ -16,6 +16,8 @@
 
 package io.rsocket;
 
+import static io.rsocket.plugins.DuplexConnectionInterceptor.Type.STREAM_ZERO;
+
 import io.rsocket.exceptions.InvalidSetupException;
 import io.rsocket.exceptions.SetupException;
 import io.rsocket.fragmentation.FragmentationDuplexConnection;
@@ -31,15 +33,12 @@ import io.rsocket.plugins.*;
 import io.rsocket.transport.ClientTransport;
 import io.rsocket.transport.ServerTransport;
 import io.rsocket.util.PayloadImpl;
-import reactor.core.publisher.Mono;
-
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-
-import static io.rsocket.plugins.DuplexConnectionInterceptor.Type.STREAM_ZERO;
+import reactor.core.publisher.Mono;
 
 /** Factory for creating RSocket clients and servers. */
 public class RSocketFactory {

--- a/rsocket-core/src/test/java/io/rsocket/RSocketRequesterTest.java
+++ b/rsocket-core/src/test/java/io/rsocket/RSocketRequesterTest.java
@@ -30,7 +30,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
 import io.rsocket.exceptions.ApplicationException;
-import io.rsocket.exceptions.RejectedSetupException;
 import io.rsocket.frame.RequestFrameFlyweight;
 import io.rsocket.test.util.TestSubscriber;
 import io.rsocket.util.PayloadImpl;

--- a/rsocket-examples/src/main/java/io/rsocket/examples/transport/tcp/lease/LeaseClientServeReqRep.java
+++ b/rsocket-examples/src/main/java/io/rsocket/examples/transport/tcp/lease/LeaseClientServeReqRep.java
@@ -8,6 +8,7 @@ import io.rsocket.transport.netty.client.TcpClientTransport;
 import io.rsocket.transport.netty.server.NettyContextCloseable;
 import io.rsocket.transport.netty.server.TcpServerTransport;
 import io.rsocket.util.PayloadImpl;
+import java.time.Duration;
 import java.util.Date;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -42,6 +43,7 @@ public class LeaseClientServeReqRep {
     RSocket clientSocket =
         CoolRSocketFactory.connect()
             .enableLease(clientLeaseControl)
+            .keepAlive(Duration.ofSeconds(1), 3, keeps -> {})
             .transport(TcpClientTransport.create("localhost", 7000))
             .start()
             .block();


### PR DESCRIPTION
Now non ClosedChannelExceptions are reported to client request handlers, and ClosedChannelException cancels sendProcessor and cleans up RSocketRequester state