### PR TITLE
Upstream bug fixes

### DIFF
--- a/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketFactory.java
@@ -388,6 +388,7 @@ public class RSocketFactory {
       private Mono<Void> processSetupFrame(ConnectionDemux multiplexer, Frame setupFrame) {
         int version = Frame.Setup.version(setupFrame);
         if (version != SetupFrameFlyweight.CURRENT_VERSION) {
+          setupFrame.release();
           InvalidSetupException error =
               new InvalidSetupException(
                   "Unsupported version " + VersionFlyweight.toString(version));

--- a/rsocket-core/src/main/java/io/rsocket/RSocketRequester.java
+++ b/rsocket-core/src/main/java/io/rsocket/RSocketRequester.java
@@ -152,7 +152,8 @@ class RSocketRequester implements RSocket {
 
   @Override
   public Flux<Payload> requestChannel(Publisher<Payload> payloads) {
-    return errorOrPublisher(() -> handleChannel(Flux.from(payloads), FrameType.REQUEST_CHANNEL), Flux::error);
+    return errorOrPublisher(
+        () -> handleChannel(Flux.from(payloads), FrameType.REQUEST_CHANNEL), Flux::error);
   }
 
   @Override
@@ -175,11 +176,9 @@ class RSocketRequester implements RSocket {
     return connection.onClose();
   }
 
-  private <T, K extends Publisher<T>> K errorOrPublisher(Supplier<K> pubSupplier,
-                                                         Function<Throwable,K> errF) {
-    return errorSignal != null
-            ? errF.apply(errorSignal)
-            : pubSupplier.get();
+  private <T, K extends Publisher<T>> K errorOrPublisher(
+      Supplier<K> pubSupplier, Function<Throwable, K> errF) {
+    return errorSignal != null ? errF.apply(errorSignal) : pubSupplier.get();
   }
 
   private Mono<Void> handleMetadataPush(Payload payload) {
@@ -189,11 +188,12 @@ class RSocketRequester implements RSocket {
   }
 
   private Mono<Void> handleFireAndForget(Payload payload) {
-    return started.then(Mono.fromRunnable(
+    return started.then(
+        Mono.fromRunnable(
             () -> {
               final int streamId = streamIdSupplier.nextStreamId();
               final Frame requestFrame =
-                      Frame.Request.from(streamId, FrameType.FIRE_AND_FORGET, payload, 1);
+                  Frame.Request.from(streamId, FrameType.FIRE_AND_FORGET, payload, 1);
               sendProcessor.onNext(new Send(requestFrame));
             }));
   }

--- a/rsocket-core/src/main/java/io/rsocket/lease/LeaseInterceptor.java
+++ b/rsocket-core/src/main/java/io/rsocket/lease/LeaseInterceptor.java
@@ -248,14 +248,13 @@ public class LeaseInterceptor implements DuplexConnectionInterceptor {
     @Override
     public Mono<Void> send(Publisher<Frame> frames) {
       return super.send(
-              Flux.from(frames)
-                      .concatMap(
-                              frame -> {
-                                Function<Frame, Frame> f =
-                                        isLeaseEnabled() ? this::handleFrame : Function.identity();
-                                return mono(f).apply(frame);
-                              })
-      );
+          Flux.from(frames)
+              .concatMap(
+                  frame -> {
+                    Function<Frame, Frame> f =
+                        isLeaseEnabled() ? this::handleFrame : Function.identity();
+                    return mono(f).apply(frame);
+                  }));
     }
 
     private Function<Frame, Mono<Frame>> mono(Function<Frame, Frame> f) {

--- a/rsocket-core/src/test/java/io/rsocket/test/util/TestDuplexConnection.java
+++ b/rsocket-core/src/test/java/io/rsocket/test/util/TestDuplexConnection.java
@@ -85,12 +85,13 @@ public class TestDuplexConnection implements DuplexConnection {
 
   @Override
   public Mono<Void> close() {
+    close.onComplete();
     return close;
   }
 
   @Override
   public Mono<Void> onClose() {
-    return close();
+    return close;
   }
 
   public Frame awaitSend() throws InterruptedException {


### PR DESCRIPTION
Fix uptream bugs:

* fix bug when current RSocket requester streams do not get terminated on connection close

* fix bug when RSocket requester streams hang if issued after connection close. Expected to get ClosedChannelException error signal immediately 

* minor: release Setup frame if connection is closed due to version mismatch 